### PR TITLE
Fix selectors for Hangouts/call and add notifications

### DIFF
--- a/assets/js/update.js
+++ b/assets/js/update.js
@@ -2,6 +2,7 @@ var microphoneSelector;
 var webcamSelector;
 var stateSelector;
 
+// These are old I think and doesn't apply to anything anymore
 microphoneSelector = '.gbbhzb';
 webcamSelector = '.YczAdf';
 webcamStateClass = 'U8OAre';
@@ -9,24 +10,34 @@ webcamStateClass = 'U8OAre';
 if (document.location.href.indexOf("://meet.google.com/") > -1) {
     microphoneSelector ='.M3NQIf .cwIDqe';
     webcamSelector = '.RTgYBc .cwIDqe'
-} else if (document.location.href.indexOf("://hangouts.google.com/") > -1) {
+} else if (document.location.href.indexOf("://hangouts.google.com/hangouts") > -1) {
     microphoneSelector = '.IQ';
-    webcamSelector = '.QQ';
-    webcamStateClass = 'a-b-B';    
+    webcamSelector = '.OQ';
+    webcamStateClass = 'a-b-B';
+} else if (document.location.href.indexOf("://hangouts.google.com/call") > -1) {
+    microphoneSelector = '.xdiH8e';
+    webcamSelector = '.WGQfVc';
+    webcamStateClass = 'U8OAre';
 }
 
 chrome.runtime.onMessage.addListener(function(request, sender, sendResponse) {
     if (request == 'toggle') {
-        updateButton(microphoneSelector); // Microphone
-        updateButton(webcamSelector); // Webcam
-
+        if (updateButton(microphoneSelector) && // Microphone
+            updateButton(webcamSelector)); {// Webcam
+            notifyUser("Mic & Cam toggled!");
+        }
+        
         return true;
     } else if (request == 'toggleMicrophone') {
-        updateButton(microphoneSelector); // Microphone
+        if(updateButton(microphoneSelector)){ // Microphone
+            notifyUser("Mic toggled!");
+        }
     } else if (request == 'toggleWebcam') {
-        updateButton(webcamSelector); // Webcam
+        if(updateButton(webcamSelector)){ // Webcam
+            notifyUser("Cam toggled!");
+        } 
     }
-
+    
     return false;
 });
 
@@ -34,8 +45,11 @@ function updateButton(selector, state) {
     var button = document.querySelector(selector);
     if (!button) {
         console.warn('Mute/unmute Button is not found (used selector: ' + selector + ')');
+        return false;
     }
+    
     simulateClick(button);
+    return true;
 }
 
 function simulateClick (element) {
@@ -48,3 +62,29 @@ function simulateClick (element) {
     initEvent(element, 'click');
     initEvent(element, 'mouseup');
 }
+
+function notifyUser(message) {
+    console.log('notifyUser', message);
+
+    // Let's check if the browser supports notifications
+    if (!("Notification" in window)) return;
+  
+    // Let's check whether notification permissions have already been granted
+    if (Notification.permission === "granted") {
+      // If it's okay let's create a notification
+      var notification = new Notification(message);
+    }
+  
+    // Otherwise, we need to ask the user for permission
+    else if (Notification.permission !== "denied") {
+      Notification.requestPermission(function (permission) {
+        // If the user accepts, let's create a notification
+        if (permission === "granted") {
+          var notification = new Notification(message);
+        }
+      });
+    }
+  
+    // At last, if the user has denied notifications, and you 
+    // want to be respectful there is no need to bother them any more.
+  }


### PR DESCRIPTION
Hi!

I had started fixing this extension and then I found your fork, so I thought it would be a good idea to join forces ;)

One thing I noted is that there seems to be two versions of Hangouts, one that starts with
`...hangouts.com/hangouts` and the other with `...hangouts.com/call`, they use different classes and look a bit different also. 

So in this PR:
- I modified the code to address the difference between hangouts versions
- Fixed a selector for the `...hangouts.com/hangouts` camera button
- Added notifications so the user knows that he toggled something without having to look at the HO screen. This needs more work because it would be nice to say if things got muted or unmuted, and also notifications were wonky on my Chrome (they flashed and disappeared too fast), haven't tested much. I also decided to go for the webExtensions notifications API and not the Chrome ones so this gets easier to migrate to Firefox in the future.
https://developer.chrome.com/extensions/desktop_notifications

Hope you find this useful! Thanks!